### PR TITLE
Update bridge EAP version

### DIFF
--- a/src/version.json
+++ b/src/version.json
@@ -5,6 +5,6 @@
     }, 
     "bridge": {
         "stable": [ "0.5.2", "0.6.2"],
-        "prerelease": ["0.7.0.EAP"]
+        "prerelease": ["0.7.0-eap20200617"]
     }
 }


### PR DESCRIPTION
Update to include the current bridge EAP version linked [here](https://keptn.sh/docs/0.6.0/reference/keptnsbridge/#early-access-version-of-keptn-bridge).