### PR TITLE
#11 Allow specifying a keptn version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ jobs:
           ls -la src/
           travis_terminate 1
         fi
+      # ensure that get.sh and version.json exist in src folder
       - cat src/get.sh || travis_terminate 1
       - cat src/version.json || travis_terminate 1
     deploy:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
 # get.keptn.sh repository
 
-This repo is part of the [Keptn Project](https://keptn.sh) and provides the auto installation script for the Keptn CLI (for osx and linux) which is published on `https://get.keptn.sh`.
+This repo is part of the [Keptn Project](https://keptn.sh) and provides the following two files:
 
-# Process Details
+* [version.json](src/version.json) - contains information about the available Keptn versions, published to https://get.keptn.sh/version.json
+* [get.sh](src/get.sh) - auto installation script for the keptn CLI (for osx and linux) which is published on `https://get.keptn.sh` (e.g., run `curl -sL https://get.keptn.sh | sudo -E bash`)
 
-If a new Keptn GA release is published on GitHub we will create a Pull Request in this repo with the the updated version of `get.sh` and `version.json`. Once this is merged, the changes will be automatically uploaded to `https://get.keptn.sh`.
+## Process Details
+
+If a new Keptn GA release is published on GitHub we will create a Pull Request in this repo with the the updated version of `get.sh` and `version.json`. Once this is merged, the changes should be uploaded to `https://get.keptn.sh`.
+
+## get.sh params
+
+Currently, the following parameters are available:
+
+* `KEPTN_VERSION` (points to a GitHub Release of [keptn/keptn](https://github.com/keptn/keptn/releases)), e.g., `0.6.2`
 
 # License
 

--- a/src/get.sh
+++ b/src/get.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # latest GA release
-KEPTN_VERSION="0.6.2"
+KEPTN_VERSION=${KEPTN_VERSION:-"0.6.2"}
 
 if [[ "$OSTYPE" == "linux-gnu" ]]; then
         DISTR="linux"


### PR DESCRIPTION
This PR implements #11, more specifically the following installation options should now work:

* Install the recommended version
```console
curl -sL https://get.keptn.sh | sudo -E bash
```
* Install a specific version (e.g., 0.6.1):
```console
curl -sL https://get.keptn.sh | KEPTN_VERSION=0.6.1 sudo -E bash
```

To test it, check out this PR's code of get.sh and run

```console
cat src/get.sh | KEPTN_VERSION=0.6.1 sudo -E bash
```

