### PR TITLE
Removed link to Azure DevOps tutorial (0.6.x)

### DIFF
--- a/src/integrations.html
+++ b/src/integrations.html
@@ -1,7 +1,7 @@
 <h2>Custom Integrations on Keptn Sandbox</h2>
 <ul>
     <li>
-        <p>Azure DevOps Keptn Integration: <a href="https://github.com/keptn-sandbox/keptn-azure-devops-extension">GitHub</a> | <a href="https://tutorials.keptn.sh/tutorials/keptn-azure-devops/index.html?">Tutorial</a></p>
+        <p>Azure DevOps Keptn Integration: <a href="https://github.com/keptn-sandbox/keptn-azure-devops-extension">GitHub</a></p>
     </li>
     <li>
         <p>GitLab: <a href="https://github.com/keptn-sandbox/gitlab-service">GitHub</a></p>


### PR DESCRIPTION
Removed the link to the Azure DevOps tutorial since it is for Keptn 0.6 and not 0.7