### PR TITLE
Fix verification step in validate_content for Windows

### DIFF
--- a/.github/workflows/validate_content.yaml
+++ b/.github/workflows/validate_content.yaml
@@ -28,5 +28,9 @@ jobs:
     steps:
       - name: Trying installing Keptn using curl get.keptn.sh (QuickStart)
         run: curl -sL https://get.keptn.sh | bash
-      - name: Verify Keptn CLI works
+      - name: Verify Keptn CLI works (Windows)
+        if: runner.os == 'Windows'
+        run: ./keptn version
+      - name: Verify Keptn CLI works (Linux, MacOS)
+        if: runner.os != 'Windows'
         run: keptn version


### PR DESCRIPTION
Signed-off-by: Christian Kreuzberger <christian.kreuzberger@dynatrace.com>

Currently, the [scheduled GH Action for validating that get.keptn.sh is working](https://github.com/keptn/get.keptn.sh/runs/1685693357?check_suite_focus=true) is failing with 
```
line 1: keptn: command not found
Error: Process completed with exit code 127.
```

I've added the same if statements as already present in the other actions to accomodate for it.